### PR TITLE
Work around Closure @nosideeffects annotations on document.createElement

### DIFF
--- a/iron-a11y-announcer.html
+++ b/iron-a11y-announcer.html
@@ -114,7 +114,7 @@ Note: announcements are only audible if you have a screen reader enabled.
 
       Polymer.IronA11yAnnouncer.requestAvailability = function() {
         if (!Polymer.IronA11yAnnouncer.instance) {
-          document.createElement('iron-a11y-announcer');
+          Polymer.IronA11yAnnouncer.instance = document.createElement('iron-a11y-announcer');
         }
 
         document.body.appendChild(Polymer.IronA11yAnnouncer.instance);


### PR DESCRIPTION
IronA11yAnnouncer uses a monostate pattern to create a global
singleton pattern to manage its instances, using the created listener
to attach an instance to the global variable. However, when using
Closure, createElement is marked as @nosideeffects and the call is
dead-code-eliminated. Work around this by storing the result.
