### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "paper-styles": "polymerelements/paper-styles#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "*"
+    "web-component-tester": "polymer/web-component-tester#^3.4.0"
   },
   "ignore": []
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,14 +19,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <title>iron-a11y-announcer demo</title>
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
   <link rel="import" href="x-announces.html">
 
-
 </head>
 <body>
-  <div class="horizontal center-justified layout">
+  <div class="horizontal-section-container">
     <div>
       <div class="vertical-section">
         <span>Note: in order to hear the announcements, be sure to turn on your favorite screen reader!</span>

--- a/test/iron-a11y-announcer.html
+++ b/test/iron-a11y-announcer.html
@@ -15,10 +15,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="../../polymer/polymer.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-a11y-announcer.html">
 </head>
 <body>
@@ -56,4 +54,3 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </body>
 </html>
-


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way
